### PR TITLE
Option 2: new snippet with dict items and simpler code

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,17 +41,17 @@ title: A Fast and Powerful Scraping and Web Crawling Framework
       </div>
       <div class="box-code">
         <p><span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install scrapy<br />
-        <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> cat > myspider.py &lt;&lt;EOF<br /><br />
-        <span class="green bold">from</span> <span class="blue bold">scrapy</span> <span class="green bold">import</span> Spider, Item, Field<br />
+        <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> cat > myspider.py &lt;&lt;EOF<br />
         <br />
-        <span class="green bold">class</span> <span class="blue bold">Post</span>(Item):<br />
-            <span>&nbsp;&nbsp;&nbsp;&nbsp;title = Field()</span><br />
+        <span class="green bold">import</span> scrapy<br />
         <br />
-        <span class="green bold">class</span> <span class="blue bold">BlogSpider</span>(Spider):<br />
-        <span>&nbsp;&nbsp;&nbsp;&nbsp;name, start_urls = '<span class="blue">blogspider</span>', ['<span class="blue">http://blog.scrapinghub.com</span>']</span><br />
+        <span class="green bold">class</span> <span class="blue bold">BlogSpider</span>(scrapy.Spider):<br />
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;name = <span class="blue">'blogspider'</span></span><br />
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;start_urls = [<span class="blue">'http://blog.scrapinghub.com'</span>]</span><br />
         <br />
         <span class="green bold">&nbsp;&nbsp;&nbsp;&nbsp;def</span> <span class="blue">parse</span>(<span class="green">self</span>, response):<br />
-        <span class="green bold">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return</span> [Post(title=e.extract()) <span class="green bold">for</span> e <span class="green bold">in</span> response.css(<span class="blue">"h2 a::text"</span>)]<br />
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="green bold">for</span> post_title <span class="green bold">in</span> response.css(<span class="blue">'h2 a::text'</span>):<br />
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;yield {<span class="blue">'title'</span>: post_title.extract()}<br />
         <br />
         EOF<br />
         <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> scrapy runspider myspider.py</p>

--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@ title: A Fast and Powerful Scraping and Web Crawling Framework
         <span>&nbsp;&nbsp;&nbsp;&nbsp;start_urls = [<span class="blue">'http://blog.scrapinghub.com'</span>]</span><br />
         <br />
         <span class="green bold">&nbsp;&nbsp;&nbsp;&nbsp;def</span> <span class="blue">parse</span>(<span class="green">self</span>, response):<br />
-        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="green bold">for</span> post_title <span class="green bold">in</span> response.css(<span class="blue">'h2 a::text'</span>):<br />
-        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;yield {<span class="blue">'title'</span>: post_title.extract()}<br />
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="green bold">for</span> post_title <span class="green bold">in</span> response.css(<span class="blue">'h2 a::text'</span>).extract():<br />
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;yield {<span class="blue">'title'</span>: post_title}<br />
         <br />
         EOF<br />
         <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> scrapy runspider myspider.py</p>


### PR DESCRIPTION
So, for Scrapy 1.0 release, I wrote two options for the snippet update: this option uses less features (just extracts the post titles), but the code is very straightforward.

Here is the snippet for this option:

```
import scrapy

class BlogSpider(scrapy.Spider):
    name = 'blogspider'
    start_urls = ['http://blog.scrapinghub.com']

    def parse(self, response):
        for post_title in response.css('h2 a::text').extract():
            yield {'title': post_title}
```

Check out option 1 as well: https://github.com/scrapy/scrapy.github.io/pull/29

Personally, I like this one better because although a bit simplistic, the code is very easy to understand.