### PR TITLE
Feature parity for the snippets

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,16 +71,19 @@ EOF
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install scrapy
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> cat > myspider.py &lt;&lt;EOF
 {% highlight python %}
-from scrapy import Spider, Item, Field
+import scrapy
+from urlparse import urljoin
 
-class Post(Item):
-    title = Field()
-
-class BlogSpider(Spider):
+class Post(scrapy.Item):
+    title = scrapy.Field()
+class BlogSpider(scrapy.Spider):
     name, start_urls = 'blogspider', ['http://blog.scrapinghub.com']
-
     def parse(self, response):
-        return [Post(title=e.extract()) for e in response.css("h2 a::text")]
+        for url in response.css('ul li a::attr("href")').re(r'.*/\d\d\d\d/\d\d/$'):
+            yield scrapy.Request(urljoin(response.url, url), self.parse_titles)
+    def parse_titles(self, response):
+        for post_title in response.css('div.entries > ul > li a::text').extract():
+            yield Post(title=post_title)
 {% endhighlight %}
 EOF
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> scrapy runspider myspider.py


### PR DESCRIPTION
This adds feature parity for the snippets, at the cost of some blank lines.

The old one was making Scrapy 1.0 snippet look longer than 0.24.