### PR TITLE
Adding Scrapy Badges to Home, Download and Doc pages

### DIFF
--- a/_includes/badges-bar.html
+++ b/_includes/badges-bar.html
@@ -1,0 +1,17 @@
+<div class="badges-bar">
+  <a href="https://pypi.python.org/pypi/Scrapy">
+    <img alt="PyPI Version" src="https://camo.githubusercontent.com/aa264cdf106775e2ede947764e3cf3bb79b8fff4/68747470733a2f2f696d672e736869656c64732e696f2f707970692f762f5363726170792e737667" data-canonical-src="https://img.shields.io/pypi/v/Scrapy.svg" style="max-width:100%;">
+  </a>
+  <a href="http://travis-ci.org/scrapy/scrapy">
+    <img alt="Build Status" src="https://camo.githubusercontent.com/dbf9a922328ddcf26f3b97c54a8db5c826d685da/68747470733a2f2f696d672e736869656c64732e696f2f7472617669732f7363726170792f7363726170792f6d61737465722e737667" data-canonical-src="https://img.shields.io/travis/scrapy/scrapy/master.svg" style="max-width:100%;">
+  </a>
+  <a href="https://pypi.python.org/pypi/Scrapy">
+    <img alt="Wheel Status" src="https://camo.githubusercontent.com/609890facf66fde6b5065196cde85ed95efa1c43/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f776865656c2d7965732d627269676874677265656e2e737667" data-canonical-src="https://img.shields.io/badge/wheel-yes-brightgreen.svg" style="max-width:100%;">
+  </a>
+  <a href="https://github.com/scrapy/scrapy/wiki/Python-3-Porting">
+    <img alt="Python 3 Porting Status" src="https://camo.githubusercontent.com/4435e82dc7497e4e896e70483c0233ea3df6ce5d/687474703a2f2f7374617469632e7363726170792e6f72672f70793370726f67726573732f62616467652e737667" data-canonical-src="http://static.scrapy.org/py3progress/badge.svg" style="max-width:100%;">
+  </a>
+  <a href="http://codecov.io/github/scrapy/scrapy?branch=master">
+    <img alt="Coverage report" src="https://camo.githubusercontent.com/e8aa0afb265628547b91b7fd8b375cb055960860/68747470733a2f2f696d672e736869656c64732e696f2f636f6465636f762f632f6769746875622f7363726170792f7363726170792f6d61737465722e737667" data-canonical-src="https://img.shields.io/codecov/c/github/scrapy/scrapy/master.svg" style="max-width:100%;">
+  </a>
+</div>

--- a/css/main.scss
+++ b/css/main.scss
@@ -307,6 +307,7 @@ dl, dd, ol, ul, figure {
 		border-bottom: $big-border-bot $dark-green;
 		@include border-radius($radius);
 		float:right;
+		min-width: 310px;
 
 		 p {
 			font-size:48px;
@@ -408,6 +409,17 @@ dl, dd, ol, ul, figure {
 		margin-right:5px;
 		cursor:pointer;
 	}
+
+// Badges Bar //
+
+div.badges-bar {
+	float: left;
+	margin-top: -25px;
+
+	a {
+		text-decoration: none;
+	}
+}
 
 // Second Row //
 

--- a/doc.html
+++ b/doc.html
@@ -34,6 +34,8 @@ permalink: doc/
 		</div>
 	</div>
 
+	{% include badges-bar.html %}
+
 </div>
 
 </div>

--- a/download.html
+++ b/download.html
@@ -34,6 +34,8 @@ permalink: download/
 		</div>
 	</div>
 
+	{% include badges-bar.html %}
+
 </div>
 	
 </div>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@ title: A Fast and Powerful Scraping and Web Crawling Framework
       </div>
     </div>
 
+    {% include badges-bar.html %}
+
   </div>
 </div>
 


### PR DESCRIPTION
Badges as seen in the [Scrapy repo](https://github.com/scrapy/scrapy).

Screenshots:

Home Page
---
<img width="1017" alt="captura de tela 2015-08-20 as 20 35 39" src="https://cloud.githubusercontent.com/assets/6334727/9398310/49be8540-477c-11e5-9950-cdddbf911ab6.png">

Download Page
---
<img width="1032" alt="captura de tela 2015-08-20 as 20 36 06" src="https://cloud.githubusercontent.com/assets/6334727/9398316/5746c736-477c-11e5-8068-a00c5d648a5d.png">

Documentation Page
---
<img width="1040" alt="captura de tela 2015-08-20 as 20 36 29" src="https://cloud.githubusercontent.com/assets/6334727/9398322/60a07f70-477c-11e5-9b77-294e042cacc5.png">
