### PR TITLE
Remove code for older version 0.24 from front page

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -478,7 +478,6 @@ div.badges-bar {
 		padding: 3px;
 
 		p {
-			float: left;
 			padding: 3px 5px;
 			margin-top: 3px;
 		}

--- a/index.html
+++ b/index.html
@@ -40,12 +40,8 @@ title: A Fast and Powerful Scraping and Web Crawling Framework
     <div class="code-box">
       <div class="box-header">
         <p>Sample Codes:</p>
-        <ul class="simple-tabs" id="code-tabs">
-          <li class="scrapy-10 active">Scrapy 1.0</li>
-          <li class="scrapy-024">Scrapy 0.24 (old stable)</li>
-        </ul>
       </div>
-      <div class="box-code tab-page active-page" id="scrapy-10">
+      <div class="box-code tab-page active-page">
         <pre>
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install scrapy
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> cat > myspider.py &lt;&lt;EOF
@@ -66,28 +62,6 @@ class BlogSpider(scrapy.Spider):
 {% endhighlight %}EOF
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> scrapy runspider myspider.py
 </pre>
-      </div>
-      <div class="box-code tab-page" id="scrapy-024">
-        <pre>
-<span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install scrapy
-<span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> cat > myspider.py &lt;&lt;EOF
-{% highlight python %}
-import scrapy
-from urlparse import urljoin
-
-class Post(scrapy.Item):
-    title = scrapy.Field()
-class BlogSpider(scrapy.Spider):
-    name, start_urls = 'blogspider', ['http://blog.scrapinghub.com']
-    def parse(self, response):
-        for url in response.css('ul li a::attr("href")').re(r'.*/\d\d\d\d/\d\d/$'):
-            yield scrapy.Request(urljoin(response.url, url), self.parse_titles)
-    def parse_titles(self, response):
-        for post_title in response.css('div.entries > ul > li a::text').extract():
-            yield Post(title=post_title)
-{% endhighlight %}EOF
-<span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> scrapy runspider myspider.py
-        </pre>
       </div>
     </div>
 


### PR DESCRIPTION
Before:

![selection_068](https://cloud.githubusercontent.com/assets/37565/10400314/52f376be-6e8e-11e5-88ff-00965fdd7bdf.png)


After:

![selection_067](https://cloud.githubusercontent.com/assets/37565/10400323/57a7ddee-6e8e-11e5-8948-f240165b3cd8.png)

Tested on both Chrome and FF.