### PR TITLE
Link format updates, rtd for docs and version for files

### DIFF
--- a/_data/scrapy.yml
+++ b/_data/scrapy.yml
@@ -5,6 +5,6 @@ oldstable:
   version: 0.24
   rtd: 0.24
 development:
-  version: 1.1
+  version: master
   rtd: master
 

--- a/download.html
+++ b/download.html
@@ -23,14 +23,14 @@ permalink: download/
 			<p> <i class="fa fa-download"> </i> Scrapy {{ stable.version }} </p>
 			<a href="http://pypi.python.org/pypi/Scrapy"><button>PyPI</button></a>
 			<a href="http://doc.scrapy.org/en/{{ stable.rtd }}/topics/ubuntu.html"><button>Ubuntu Package</button></a>
-			<a href="https://github.com/scrapy/scrapy/tarball/{{ stable.rtd }}"><button>Tarball</button></a>
-			<a href="https://github.com/scrapy/scrapy/zipball/{{ stable.rtd }}"><button>Zip</button></a>
+			<a href="https://github.com/scrapy/scrapy/archive/{{ stable.version }}.tar.gz"><button>Tarball</button></a>
+			<a href="https://github.com/scrapy/scrapy/archive/{{ stable.version }}.zip"><button>Zip</button></a>
 		</div>
 		<div class="developer-branch">
 			<i class="fa fa-code-fork"></i>
 			<p>You can also download <br /><span class="highlight">the development branch</span></p>
-			<a href="https://github.com/scrapy/scrapy/tarball/{{ devel.rtd }}"><button>Tarball</button></a>
-			<a href="https://github.com/scrapy/scrapy/zipball/{{ devel.rtd }}"><button>Zip</button></a>
+			<a href="https://github.com/scrapy/scrapy/archive/{{ devel.version }}.tar.gz"><button>Tarball</button></a>
+			<a href="https://github.com/scrapy/scrapy/archive/{{ devel.version }}.zip"><button>Zip</button></a>
 		</div>
 	</div>
 
@@ -43,8 +43,8 @@ permalink: download/
 <div class="third-row-down">
 <div class="container">
 	<div class="block-left">
-		<a href="https://github.com/scrapy/scrapy/archive/{{ oldstable.rtd }}.zip">
-		<h2 class="float">Looking for an old release? <br /> Download Scrapy {{ oldstable.rtd }}</h2>
+		<a href="https://github.com/scrapy/scrapy/archive/{{ oldstable.version }}.zip">
+		<h2 class="float">Looking for an old release? <br /> Download Scrapy {{ oldstable.version }}</h2>
 		<i class="fa fa-archive fa-3x"></i>
 		</a>
 		<p>Or you can find even older releases and changes here:</p>

--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@ title: A Fast and Powerful Scraping and Web Crawling Framework
         <p> <i class="fa fa-download"> </i> Scrapy {{ stable.version }} </p>
         <div class="install-code"><span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install scrapy</div>
         <a href="http://pypi.python.org/pypi/Scrapy"><button>PyPI</button></a>
-        <a href="http://doc.scrapy.org/en/{{ stable.version }}/topics/ubuntu.html"><button>Ubuntu Package</button></a>
-        <a href="https://github.com/scrapy/scrapy/tarball/{{ stable.version }}"><button>Tarball</button></a>
-        <a href="https://github.com/scrapy/scrapy/zipball/{{ stable.version }}"><button>Zip</button></a>
+        <a href="http://doc.scrapy.org/en/{{ stable.rtd }}/topics/ubuntu.html"><button>Ubuntu Package</button></a>
+        <a href="https://github.com/scrapy/scrapy/archive/{{ stable.version }}.tar.gz"><button>Tarball</button></a>
+        <a href="https://github.com/scrapy/scrapy/archive/{{ stable.version }}.zip"><button>Zip</button></a>
       </div>
     </div>
 


### PR DESCRIPTION
In /downloads, https://github.com/scrapy/scrapy/tarball/latest and https://github.com/scrapy/scrapy/zipball/latest aren't working, seems Github no longer supports that latest special URL

- Fixed broken URLs
- Updated link structure to `https://github.com/scrapy/scrapy/archive/[version].[extension]`, more future-proof according to @ddebernardy
- Used `{{ devel.rtd }}`, `{{ stable.rtd }}` and `{{ oldstable.rtd }}` for read the docs links
- Used `{{ devel.version }}`, `{{ stable.version }}` and `{{ oldstable.version }}` for file download links
- Updated `devel.version` in the YML file to `master` (as we don't have a 1.1 branch for development)

Closes #49 