### PR TITLE
Changes to the second terminal window

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -90,6 +90,10 @@ dl, dd, ol, ul, figure {
 		font-weight:bold;
 	}
 
+	a .highlight {
+		text-decoration:underline;
+	}
+
 	a {
 		text-decoration:underline;
 		font-weight:bold;

--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@ class BlogSpider(scrapy.Spider):
       </div>
       <div class="box-code tab-page active-page">
         <pre>
-<span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install shub
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> shub login
 <span class="comments">Insert your Scrapinghub API Key: <span class="placeholder">&lt;API_KEY&gt;</span></span>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ class BlogSpider(scrapy.Spider):
       </div>
     </div>
 
-    <div class="code-subs"><p>Build and run your <br /><span class="highlight">web spiders</span></p></div>
+    <div class="code-subs"><p>Build and run your<br /><span class="highlight">web spiders</span></p></div>
 
   </div>
 
@@ -89,7 +89,7 @@ https://dash.scrapinghub.com/p/26731/job/1/18</span>
     </div>
 
     <div class="code-subs"><p>Deploy them to<br /><a href="http://scrapinghub.com/scrapy-cloud/" title=""><span class="highlight">Scrapy Cloud</span></a></p>
-    <p class="sub-sub">or use <a href="https://github.com/scrapy/scrapyd" title="Scrapyd"><span class="highlight">Scrapyd</span></a> to host the spiders in your own server</p></div>
+    <p class="sub-sub">or use <a href="https://github.com/scrapy/scrapyd" title="Scrapyd"><span class="highlight">Scrapyd</span></a> to host the spiders on your own server</p></div>
   </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -63,10 +63,11 @@ class BlogSpider(scrapy.Spider):
   <div class="container code-box-line">
     <div class="code-box">
       <div class="box-header">
-        <p>Terminal session to illustrate (assumes you have signed up to Scrapinghub)<span class="close-btn">&bull;</span></p>
+        <p>Terminal<span class="close-btn">&bull;</span></p>
       </div>
       <div class="box-code tab-page active-page">
         <pre>
+<span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install shub
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> shub login
 <span class="comments">Insert your Scrapinghub API Key: <span class="placeholder">&lt;API_KEY&gt;</span></span>
 
@@ -75,7 +76,7 @@ class BlogSpider(scrapy.Spider):
 
 <span class="comments"># Schedule the spider for execution</span>
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> shub schedule blogspider <span class="comments">
-Spider bestbuy scheduled, watch it running here:
+Spider blogspider scheduled, watch it running here:
 https://dash.scrapinghub.com/p/26731/job/1/18</span>
 
 <span class="comments"># Retrieve the scraped data</span>


### PR DESCRIPTION
I am doing this PR to propose some changes to the second terminal window:

**Change the terminal title**
Replace "Terminal session to illustrate (assumes you have signed up to Scrapinghub)" by only "Terminal". Since the user is asked to provide his/her API Key when he/she runs `shub login` in the illustrated session, the reader could infer that the sign up to Scrapinghub is required.

**Add the shub installation cmd again**
In the first window, we have `pip install scrapy`. So, for consistency, we could keep `pip install shub` in the second one.


There is also a fix on the output by `shub schedule`, replacing `bestbuy` by `blogspider`.