### PR TITLE
Fix SayOne missing logo

### DIFF
--- a/support.html
+++ b/support.html
@@ -29,7 +29,7 @@ permalink: support/
 		<div class="company-longbox">
 			<div class="logo-wrap">
 				<a href="http://sayonetech.com/">
-				<img src="../img/sayone-logo.png" />
+				<img src="../img/46-sayone-logo.png" />
 				</a>
 			</div>
 


### PR DESCRIPTION
SayOne logo was not showing up at http://scrapy.org/support/, because of a change in the filename.