### PR TITLE
Fix Segment code and update GA snippet to the most recent version

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,22 +1,21 @@
-<script type="text/javascript">
-  var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-  document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-  </script>
-  <script type="text/javascript">
-    try {
-      var pageTracker = _gat._getTracker("UA-10231918-1");
-      pageTracker._trackPageview();
-    } catch(err) {}
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','gaScrapy');
+
+gaScrapy('create', 'UA-10231918-1', 'auto');
+gaScrapy('send', 'pageview');
 </script>
 
 <script type="text/javascript">
 !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
 analytics.load("8UDQfnf3cyFSTsM4YANnW5sXmgZVILbA");
+analytics.page();
 }}();
 
 analytics.ready(function () {
     ga('require', 'linker');
     ga('linker:autoLink', ['scrapinghub.com', 'crawlera.com']);
-    analytics.page();
 });
 </script>


### PR DESCRIPTION
Segment tracking hasn't been working since April for our websites.

This PR fix the Segment tracking code to make it work on scrapy.org again.

It also updates the Google Analytics snippet to the latest version, [using `analytics.js` instead of `ga.js`](https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs).
