### PR TITLE
Remove download count badge from badges-bar

### DIFF
--- a/_includes/badges-bar.html
+++ b/_includes/badges-bar.html
@@ -3,9 +3,6 @@
     <img alt="PyPI Version" src="https://img.shields.io/pypi/v/Scrapy.svg" style="max-width:100%;">
   </a>
   <a href="https://pypi.python.org/pypi/Scrapy">
-    <img alt="PyPI monthly downloads" src="https://img.shields.io/pypi/dm/Scrapy.svg" style="max-width:100%;">
-  </a>
-  <a href="https://pypi.python.org/pypi/Scrapy">
     <img alt="Wheel Status" src="https://img.shields.io/badge/wheel-yes-brightgreen.svg" style="max-width:100%;">
   </a>
   <a href="https://github.com/scrapy/scrapy/wiki/Python-3-Porting">


### PR DESCRIPTION
I removed the download stats badge because it's apparently broken. It's been showing small numbers for quite some time.