### PR TITLE
Deprecate ubuntu packages (see scrapy#2137)

### DIFF
--- a/_includes/download-button.html
+++ b/_includes/download-button.html
@@ -7,7 +7,6 @@
   <div class="download-alternatives">
     <a href="http://pypi.python.org/pypi/Scrapy"><button>PyPI</button></a>
     <a href="https://anaconda.org/scrapinghub/scrapy"><button>Conda</button></a>
-    <a href="http://doc.scrapy.org/en/{{ stable.rtd }}/topics/ubuntu.html"><button>APT</button></a>
     <a href="https://github.com/scrapy/scrapy/archive/{{ stable.version }}.zip"><button>Source</button></a>
   </div>
 </div>


### PR DESCRIPTION
Removing the APT link, as per https://github.com/scrapy/scrapy/issues/2137