### PR TITLE
install shub missing on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@ class BlogSpider(scrapy.Spider):
       </div>
       <div class="box-code tab-page active-page">
         <pre>
+<span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> pip install shub
 <span class="prompt" onselectstart="return false"><i class="fa fa-dollar"></i></span> shub login
 <span class="comments">Insert your Scrapinghub API Key: <span class="placeholder">&lt;API_KEY&gt;</span></span>
 


### PR DESCRIPTION
It could be confusing for beginners, as they could assume `scrapy` comes with the installation of `shub`.

[example](http://stackoverflow.com/questions/42448273/where-is-the-shub-command)