### PR TITLE
Remove a couple companies from Commercial Support page

### DIFF
--- a/companies.html
+++ b/companies.html
@@ -53,18 +53,6 @@ redirect_from:
 
     <div class="company-longbox">
       <div class="logo-wrap">
-        <a href="http://www.flax.co.uk/">
-        <img src="../img/flax-logo.gif" />
-        </a>
-      </div>
-      <p>
-        <a href="http://www.flax.co.uk/">Flax</a>
-        are experts in open source search and have used Scrapy in several projects, for clients in sectors including publishing, recruitment and broadcast. We recommend Scrapy as a first choice to clients looking to gather content for a search application.
-      </p>
-    </div>
-
-    <div class="company-longbox">
-      <div class="logo-wrap">
         <a href="http://www.goscrape.com/">
         <img src="../img/goscrape-logo.png" />
         </a>
@@ -72,18 +60,6 @@ redirect_from:
       <p>
         <a href="http://www.goscrape.com/">GoScrape</a>
         specializes in developing web crawlers via Scrapy for fulfilling information needs. Their core services include scraping, crawling, and parsing data from a variety of sources; interacting with web APIs; and cleansing, analyzing, and presenting data using a variety of methods.
-      </p>
-    </div>
-
-    <div class="company-longbox">
-      <div class="logo-wrap">
-        <a href="http://arbisoft.com/services/">
-        <img src="../img/arbisoft-logo.png" />
-        </a>
-      </div>
-      <p>
-        <a href="http://arbisoft.com/services/">Arbisoft</a>
-        is using Scrapy for a number of aggregation projects for our clients and partners. They have more than 20 trained Scrapy/Python engineers and usually recommend it as the first choice when their partners ask for scraping services.
       </p>
     </div>
 


### PR DESCRIPTION
To make sure that Scrapy.org's "Companies" page is up to date, we sent emails (2 weeks ago) to the companies listed under the "Commercial support" section asking if they still provide Scrapy support. This PR removes the ones that haven't replied.