### PR TITLE
Replaces mailing list by subreddit as discussion channel

### DIFF
--- a/community.html
+++ b/community.html
@@ -13,39 +13,26 @@ permalink: community/
   <p>Scrapy has a healthy and active community. Check the places where you can get help and find the latests Scrapy news.</p>
 
   <div class="community-box">
-    <h2>Getting involved <br />and contributing</h2>
-    <a href="https://github.com/scrapy/scrapy">
-      <i class="fa fa-github"></i>
-    </a>
+    <h2><i class="fa fa-github"></i>Getting involved</h2>
     <hr />
     <p>
-      If you want to get involved and contribute patches or help documenting,
-      start by reading <a href="http://doc.scrapy.org/en/{{ devel.rtd }}/contributing.html">Contributing to Scrapy</a>.
+      If you want to get involved and contribute with patches or documentation,
+      start by reading <a href="http://doc.scrapy.org/en/{{ devel.rtd }}/contributing.html">this quick guide</a>.
       All development happens on the <a href="https://github.com/scrapy/scrapy">Scrapy Github project</a>.
     </p>
-    <a href="https://github.com/scrapy/scrapy">
-      <button>Contribute now</button>
-    </a>
+    <a href="https://github.com/scrapy/scrapy"><button>Contribute now</button></a>
   </div>
 
   <div class="community-box">
-    <h2>Mailing list and <br />IRC Channel</h2>
-    <a href="http://groups.google.com/group/scrapy-users">
-      <i class="fa fa-envelope-o"></i>
+    <a href="http://reddit.com/r/scrapy">
+      <h2><i class="fa fa-reddit-alien"></i> /r/scrapy subreddit</h2>
     </a>
     <hr />
     <p>
-      Feel free to subscribe to our <a href="http://groups.google.com/group/scrapy-users">mailing list:</a>
+      The <a href="http://reddit.com/r/scrapy">Scrapy official subreddit</a> is the best place to share cool articles, spiders, Scrapy extensions and whatnots.
     </p>
-    <form action="http://groups.google.com/group/scrapy-users/boxsubscribe">
-      <input type="text" name="email" placeholder="Your e-mail here">
-      <input type="submit" value="Go">
-    </form>
     <p>
-      You can also join <span class="highlight">#scrapy IRC Channel at Freenode</span>
-      to chat with other Scrapy users& developers,
-      via <a href="http://webchat.freenode.net/?channels=scrapy">browser</a>
-      or any <a href="http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients">IRC client</a>.
+      Collaboration at any level is also encouraged there, so feel free to start a discussion, ask for code reviews and advices for your projects.
     </p>
   </div>
 
@@ -55,32 +42,21 @@ permalink: community/
     </a>
     <hr />
     <p>
-      There is a healthy community providing Scrapy help on Stack Overflow, along with the core developers.
-      The <a href="http://stackoverflow.com/questions/tagged/scrapy">scrapy tag</a> has around 6,4k questions.
-      If Stack Overflow is your preference, <a href="http://stackoverflow.com/questions/ask">ask your question there</a>.
+      If you are looking for support or troubleshooting, the <a href="http://stackoverflow.com/questions/tagged/scrapy">scrapy tag</a> at Stack Overflow is your best friend. There's a healthy community built around it with thousands of questions and many regular contributors.
+    </p>
+    <p>
+      Go ahead and <a href="http://stackoverflow.com/questions/ask">ask your question there</a>.
     </p>
   </div>
 
   <div class="community-box">
-    <a href="https://github.com/scrapy/scrapy/wiki">
-      <h2><i class="fa fa-file-text-o"></i> The Scrapy Wiki</h2>
-    </a>
+    <h2><i class="fa fa-comments-o"></i>IRC Channel</h2>
     <hr />
     <p>
-      <a href="https://github.com/scrapy/scrapy/wiki">The Scrapy wiki</a>
-      contains a compilation of many community resources such as articles,
-      blog posts, video & text tutorials, slides and talks.
-    </p>
-  </div>
-
-  <div class="community-box">
-    <a href="http://snipplr.com/all/tags/scrapy/">
-      <h2><i class="fa fa-code"></i> Code snippets</h2>
-    </a>
-    <hr />
-    <p>
-      Snipplr is very popular for sharing useful Scrapy code snippets.
-      Check out the <a href="http://snipplr.com/all/tags/scrapy/">scrapy tag on Snipplr</a>.
+      You can join the <span class="highlight">#scrapy IRC Channel at Freenode</span>
+      to chat with other Scrapy users and developers,
+      via <a href="http://webchat.freenode.net/?channels=scrapy">browser</a>
+      or any <a href="http://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients">IRC client</a>.
     </p>
   </div>
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -841,7 +841,7 @@ div.badges-bar {
 		float:left;
 		margin-right:40px;
 		margin-top:25px;
-		min-height:156px;
+		min-height:162px;
 	}
 
 	.community-box:nth-of-type(2n) {

--- a/index.html
+++ b/index.html
@@ -121,10 +121,9 @@ https://app.scrapinghub.com/p/26731/job/1/8</span>
     <div class="block-left">
       <h2>Healthy community</h2>
       <ul>
-        <li>- 18k stars, 4.7k forks and 1.3k watchers on <a href="https://github.com/scrapy/scrapy">GitHub</a></li>
+        <li>- 20k stars, 5k forks and 1.4k watchers on <a href="https://github.com/scrapy/scrapy">GitHub</a></li>
         <li>- 3.4k followers on <a href="https://twitter.com/ScrapyProject">Twitter</a></li>
-        <li>- 6.7k questions on <a href="http://stackoverflow.com/tags/scrapy/info">StackOverflow</a></li>
-        <li>- 3.1k members on <a href="https://groups.google.com/forum/?fromgroups#!aboutgroup/scrapy-users">mailing list</a></li>
+        <li>- 7.4k questions on <a href="http://stackoverflow.com/tags/scrapy/info">StackOverflow</a></li>
       </ul>
     </div>
     <div class="block-right">


### PR DESCRIPTION
This PR is part of the migration process from [scrapy-users](https://groups.google.com/forum/#!forum/scrapy-users) mailing list to [/r/scrapy](https://www.reddit.com/r/scrapy/) on reddit.

It adds /r/scrapy as the official channel for discussions regarding scrapy and removes the scrapy-users mailing list from the list of channels.

**Please, don't merge this yet.** Before doing so, we have to define precisely how we are rolling out the announcement.