### PR TITLE
Update Scrapy to 1.5 and fix a few issues with the website

### DIFF
--- a/_data/scrapy.yml
+++ b/_data/scrapy.yml
@@ -1,9 +1,9 @@
 stable:
-  version: 1.4
+  version: 1.5
   rtd: latest
 oldstable:
-  version: 1.3
-  rtd: 1.3
+  version: 1.4.0
+  rtd: 1.4
 development:
   version: master
   rtd: master

--- a/_includes/download-button.html
+++ b/_includes/download-button.html
@@ -7,6 +7,5 @@
   <div class="download-alternatives">
     <a href="http://pypi.python.org/pypi/Scrapy"><button>PyPI</button></a>
     <a href="https://anaconda.org/conda-forge/scrapy"><button>Conda</button></a>
-    <a href="https://github.com/scrapy/scrapy/archive/{{ stable.version }}.zip"><button>Source</button></a>
   </div>
 </div>

--- a/companies.html
+++ b/companies.html
@@ -27,6 +27,7 @@ redirect_from:
       {{ company.description | markdownify }}
     </div>
     {% endfor %}
+  </div>
 
   <h1>Companies using Scrapy</h1>
   <p>Check who is using Scrapy to do business and make an impact on the world.

--- a/css/main.scss
+++ b/css/main.scss
@@ -634,7 +634,7 @@ div.badges-bar {
 		@extend .third-row;
 		background-color:#f2f2f2;
 		padding-top:25px;
-		height:240px;
+		height:200px;
 
 		h2 {
 			margin-bottom:25px;
@@ -679,7 +679,7 @@ div.badges-bar {
 			padding-left:60px;
 			width:399px;
 			border-left:1px solid $default-green;
-			height:200px;
+			height:160px;
 		}
 
 		button {

--- a/download.html
+++ b/download.html
@@ -40,22 +40,19 @@ permalink: download/
 		<h2 class="float">Looking for an old release? <br /> Download Scrapy {{ oldstable.version }}</h2>
 		<i class="fa fa-archive fa-3x"></i>
 		</a>
-		<p>Or you can find even older releases and changes here:</p>
-		<ul>
-			<li><a href="https://github.com/scrapy/scrapy/tree/0.22">Scrapy 0.22</a></li>
-			<li><a href="https://github.com/scrapy/scrapy/tree/0.20">Scrapy 0.20</a></li>
-			<li><a href="https://github.com/scrapy/scrapy/tree/0.18">Scrapy 0.18</a></li>
-			<li><a href="https://github.com/scrapy/scrapy/tree/0.16">Scrapy 0.16</a></li>
-			<li><a href="https://github.com/scrapy/scrapy/tree/0.14">Scrapy 0.14</a></li>
-			<li><a href="https://github.com/scrapy/scrapy/tree/0.12">Scrapy 0.12</a></li>
-		</ul>
+		<p>
+			You can find even older releases on
+			<a href="https://github.com/scrapy/scrapy/releases">GitHub</a>.
+		</p>
 	</div>
 
 	<div class="block-right">
 		<h2>Want to contribute <br /> to Scrapy?</h2>
-		<p>Don't forget to check the <a href="http://doc.scrapy.org/en/{{ devel.rtd }}/contributing.html">Contributing Guidelines and the <a href="http://doc.scrapy.org/en/{{ devel.rtd }}/">Development Documentation online</a>.</p>
-		<a href="http://doc.scrapy.org/en/{{ devel.rtd }}/"><button>Doc</button></a>
-		<a href="http://doc.scrapy.org/en/{{ devel.rtd }}/contributing.html"><button>Guidelines</button></a>
+		<p>
+			Don't forget to check the
+			<a href="http://doc.scrapy.org/en/{{ devel.rtd }}/contributing.html">Contributing Guidelines</a>
+			and the <a href="http://doc.scrapy.org/en/{{ devel.rtd }}/">Development Documentation</a> online.
+		</p>
 	</div>
 </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -120,9 +120,9 @@ https://app.scrapinghub.com/p/26731/job/1/8</span>
     <div class="block-left">
       <h2>Healthy community</h2>
       <ul>
-        <li>- 22k stars, 5k forks and 1.5k watchers on <a href="https://github.com/scrapy/scrapy">GitHub</a></li>
-        <li>- 3.8k followers on <a href="https://twitter.com/ScrapyProject">Twitter</a></li>
-        <li>- 8.1k questions on <a href="http://stackoverflow.com/tags/scrapy/info">StackOverflow</a></li>
+        <li>- 24k stars, 6k forks and 1.6k watchers on <a href="https://github.com/scrapy/scrapy">GitHub</a></li>
+        <li>- 4.0k followers on <a href="https://twitter.com/ScrapyProject">Twitter</a></li>
+        <li>- 8.7k questions on <a href="http://stackoverflow.com/tags/scrapy/info">StackOverflow</a></li>
       </ul>
     </div>
     <div class="block-right">


### PR DESCRIPTION
* Scrapy is updated to 1.5;
* https://scrapy.org/companies/ page is fixed (scroll to the bottom to see that text in footer doesn't look good)
* "source" download button is removed from "download" widget; I don't think it was useful, and we were providing link to download code from a _branch_ corresponding to a release (which we were not always maintaining), not to a tag.
* links on https://scrapy.org/download/ page ("Want to contribute to Scrapy?") are fixed; they were over-jealous. I've also removed buttons which just duplicate links. It seems they were used to fill empty vertical space, but there is no more extra vertical space (see next)
* links to ancient releases are replaced with a link to github releases page. Selection of old releases was weird anyways - why provide a link to 0.22, but not to 1.1.4 or 1.3.3?
* github/twitter/stackoverflow stats are updated.

conda ~and rtfd~~ is not ready yet, so conda links point to 1.4.
