### PR TITLE
Correction of video link of talk by Karthik Ananth

### DIFF
--- a/_data/resources/videos.yml
+++ b/_data/resources/videos.yml
@@ -6,7 +6,7 @@
     [Companion code](https://github.com/scrapinghub/learn-scrapy).
 
 - title: "Scrapy Workshop"
-  url: https://www.youtube.com/watch?v=eD8XVXLlUTE
+  url: https://www.youtube.com/watch?v=0VssOTV5eoc
   author: Karthik Ananth
   context: PyData NYC 2015, in English
   description: |


### PR DESCRIPTION
In resources section:
Talk by Karthik Ananth point to  ```https://www.youtube.com/watch?v=eD8XVXLlUTE```
instead of ```https://www.youtube.com/watch?v=0VssOTV5eoc```

corrected the same.