### PR TITLE
css selector updated to fit current blog.scrapinghub.com css

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ class BlogSpider(scrapy.Spider):
     start_urls = ['https://blog.scrapinghub.com']
 
     def parse(self, response):
-        for title in response.css('h2.entry-title'):
+        for title in response.css('.post-header>h2'):
             yield {'title': title.css('a ::text').extract_first()}
 
         for next_page in response.css('div.prev-post > a'):


### PR DESCRIPTION
Tutorial in "scrapy.org" Home Page has a minor bug... after a blog redesign?

"h2.entry-title" Css selector should be ".post-header>h2".