### PR TITLE
WEB-132: revert meta viewport to 980

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
 	<link rel="icon" type="image/png" href="/favicons/favicon-32x32.png" sizes="32x32">
 	<meta name="msapplication-TileColor" content="#da532c">
 	<meta name="msapplication-TileImage" content="/favicons/mstile-144x144.png">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="980">
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/css/font-awesome.min.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
changed from "width=device-width" since the website does not have media queries for smaller devices yet.