### PR TITLE
Add Web Scraping Solutions to companies page: fix ranking.csv

### DIFF
--- a/_data/companies/pros/ranking.csv
+++ b/_data/companies/pros/ranking.csv
@@ -1,10 +1,10 @@
-company,score
-zyte,75
-web scraping solutions,34
-scrapeops,30
-arbisoft,10
-datahut,10
-sayone,7
-lambertlabs,7
-tryolabs,5
-intoli,5
+company,score
+zyte,75
+web scraping solutions,34
+scrapeops,30
+arbisoft,10
+datahut,10
+sayone,7
+lambertlabs,7
+tryolabs,5
+intoli,5


### PR DESCRIPTION
Build and deploy failed: https://github.com/scrapy/scrapy.org/actions/runs/9618312096/job/26531914804
Issue: The ranking.csv file was generated on Windows; the Windows newline character is different from Linux/MacOS.
I've re-generated the table in a Linux environment.